### PR TITLE
feature(nodes): refactor memory management

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "comfyui-dezoomer-nodes"
 description = "A collection of custom nodes for ComfyUI."
-version = "1.0.0"
+version = "1.0.1"
 license = {file = "LICENSE"}
 dependencies = [
     "accelerate>=0.25.0",


### PR DESCRIPTION
Add `keep_model_loaded` option to captioning nodes.

This change introduces a `keep_model_loaded` boolean parameter to the `CaptionRefinementNode` and `VideoCaptioningNode`. This parameter controls whether the model is offloaded from the GPU memory after the captioning/refinement process is completed, providing users with more control over memory management.

## Changes

- Added a `keep_model_loaded` boolean input to `CaptionRefinementNode` and `VideoCaptioningNode`.
- Modified the `captionrefinement` method in `caption_refinement.py` and `generate_caption` method in `video_captioning.py` to conditionally offload the model and tokenizer based on the value of `keep_model_loaded`. The offloading process involves deleting the model and tokenizer objects and calling `mm.soft_empty_cache()`.
- The default value for `keep_model_loaded` is `False`, meaning the model will be offloaded by default.
- Removed `clear_memory` functions from both `caption_refinement.py` and `video_captioning.py`.
- Modified the default seed value in `caption_refinement.py` to be `1` instead of `123`.
- Bumped the package version from 1.0.0 to 1.0.1 in `pyproject.toml`.

## Impact

- Users can now choose whether to keep the language model loaded in memory after caption generation, allowing for faster subsequent captioning at the cost of higher memory usage, or freeing up memory at the cost of longer load times.
- Introduces a dependency on `comfy.model_management` for memory management.
- No breaking changes are introduced.
- May improve performance in workflows that reuse the same captioning model frequently when `keep_model_loaded` is set to `True`. It may decrease memory usage when `keep_model_loaded` is `False`.